### PR TITLE
Suggest symbolic links to each directory in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,22 @@ Prerequisites:
 
 ### Steps 
 
-*cd into the skills directory*
+*cd into /opt*
 
-`cd /opt/mycroft-dinkum/skills` 
-
-*create a directory for the skill*  
-
-`mkdir bark.mark2` 
+`cd /opt`
 
 *clone this repo*  
 
 `git clone https://github.com/jmillerv/converted-skills` 
 
-*copy the skill you want into the folder you created*  
+*Change directory to the dinkum skills director*
 
-`cp -r converted-skill/* bark.mark2/` 
+`cd /opt/mycroft-dinkum/skills`
+
+
+*create a symbolic link to the skill you want*
+
+`ln -s /opt/converted-skills/bark.mark2`
 
 *Add skill to skills.json*  
 


### PR DESCRIPTION
This means the code in the skills directory is always exactly what's in the git repo

Feel free to discard this - it's just the workflow I chose to go with so I thought I'd post it here as a suggestion.